### PR TITLE
Support both XF2.0 & XF2.1

### DIFF
--- a/XFApi.php
+++ b/XFApi.php
@@ -55,17 +55,18 @@ class XFApi
 
 	public function validate()
 	{
+		$key = \XF::$versionId > 2010000 ? 'form_params' :  'body';
 		try
 		{
 			$this->rawResponse = $this->httpClient->post(self::VALIDATION_URL, [
-				'form_params' => [
+				$key => [
 					'token' => $this->token,
 					'domain' => $this->domain ?: ''
 				]
 			]);
 
 			$this->responseCode = $this->rawResponse->getStatusCode();
-			$this->responseJson = json_decode($this->rawResponse->getBody(), true);
+			$this->responseJson = \json_decode((string)$this->rawResponse->getBody(), true);
 		} catch (ClientException $e)
 		{
 			$this->responseCode = $e->getCode();

--- a/addon.json
+++ b/addon.json
@@ -9,11 +9,6 @@
   "faq_url": "",
   "support_url": "https://lw-addons.net/addons/LiamW-XenForoLicenseVerification",
   "extra_urls": [],
-  "require": {
-    "XF": [
-      2010000,
-      "XenForo 2.1.0 or above"
-    ]
-  },
+  "require": [],
   "icon": ""
 }


### PR DESCRIPTION
Note; cast getBody() results to a string to be explicit since it actually returns a StreamInterface, and json_decode takes a string.